### PR TITLE
refactor(utils.py): improve process termination handling so that mitmdump binary can clear its temporary directory

### DIFF
--- a/pomodoro-task-app/website_blocker/utils.py
+++ b/pomodoro-task-app/website_blocker/utils.py
@@ -6,7 +6,7 @@
 import os
 import shlex
 import subprocess
-
+import signal
 import psutil
 
 
@@ -33,7 +33,15 @@ def find_processes_by_name(name):
 def kill_process():
     if os.name == "nt":
         processes = find_processes_by_name("mitmdump.exe") + find_processes_by_name("mitmproxy.exe")
+        for p in processes:
+            try:
+                p.send_signal(signal.CTRL_C_EVENT)
+            except (psutil.AccessDenied, AttributeError):
+                p.kill()
     else:
         processes = find_processes_by_name("mitmdump") + find_processes_by_name("mitmproxy")
-    for p in processes:
-        p.kill()
+        for p in processes:
+            try:
+                p.send_signal(signal.SIGINT)
+            except psutil.AccessDenied:
+                p.kill()


### PR DESCRIPTION
- using `p.kill()` on the process kills it immediately without giving mitmdump binary compiled by pyinstaller to clear its temporary directory, thus filling up disk space everytime it starts and is killed