### PR TITLE
fix: change method of shutting down mitmdump to fix ctrl+c issue in unsetting proxy env vars in windows nuitka build

### DIFF
--- a/pomodoro_task_app/constants.py
+++ b/pomodoro_task_app/constants.py
@@ -45,6 +45,7 @@ BLOCK_HTML_MESSAGE = f"<h1>Website blocked by {APPLICATION_NAME}!</h1>"
 
 UPDATE_CHECK_URL = "https://raw.githubusercontent.com/kun-codes/pomodoro-task-app.py/refs/heads/main/pyproject.toml"
 NEW_RELEASE_URL = "https://github.com/kun-codes/pomodoro-task-app.py/releases/latest"
+MITMDUMP_SHUTDOWN_URL = f"http://shutdown.{APPLICATION_NAME.lower()}.internal/"
 
 
 class WebsiteFilterType(Enum):

--- a/pomodoro_task_app/utils/noHTTPClientError.py
+++ b/pomodoro_task_app/utils/noHTTPClientError.py
@@ -1,0 +1,7 @@
+class NoHTTPClientError(Exception):
+    def __init__(self, message: str):
+        super().__init__(message)
+        self.message = message
+
+    def __str__(self):
+        return f"No HTTP client found: {self.message}"

--- a/pomodoro_task_app/website_blocker/filter.py
+++ b/pomodoro_task_app/website_blocker/filter.py
@@ -11,7 +11,7 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from mitmproxy import ctx, http
 
-from constants import BLOCK_HTML_MESSAGE
+from constants import BLOCK_HTML_MESSAGE, MITMDUMP_SHUTDOWN_URL
 
 
 def load(loader):
@@ -20,6 +20,18 @@ def load(loader):
 
 
 def request(flow):
+    # https://docs.mitmproxy.org/stable/addons-examples/#shutdown
+    if flow.request.pretty_url == MITMDUMP_SHUTDOWN_URL:
+        print("Shutting down mitmdump...")
+        # Send confirmation response before shutdown
+        flow.response = http.Response.make(
+            200,
+            b"Shutting down mitmproxy...\n",
+            {"Content-Type": "text/plain"}
+        )
+        ctx.master.shutdown()
+        return
+
     addresses = ctx.options.addresses_str.split(",")
     addresses = set(addresses)
 

--- a/pomodoro_task_app/website_blocker/utils.py
+++ b/pomodoro_task_app/website_blocker/utils.py
@@ -9,6 +9,7 @@ import signal
 import subprocess
 
 import psutil
+from loguru import logger
 
 
 def exec_command(command):
@@ -32,17 +33,29 @@ def find_processes_by_name(name):
 
 
 def kill_process():
+    logger.debug("Inside kill_process().")
     if os.name == "nt":
         processes = find_processes_by_name("mitmdump.exe") + find_processes_by_name("mitmproxy.exe")
         for p in processes:
-            try:
-                p.send_signal(signal.CTRL_C_EVENT)
-            except (psutil.AccessDenied, AttributeError):
-                p.kill()
+            logger.debug(f"Trying to kill process with pid {p.pid} on Windows.")
+            p.kill()  # I couldn't find any way of stopping mitmdump gracefully on Windows
     else:
+
         processes = find_processes_by_name("mitmdump") + find_processes_by_name("mitmproxy")
+        # list all processes with id and name
+        for p in processes:
+            logger.debug(f"Found process with pid {p.pid} and name {p.info['name']}.")
+        # if no process is found then
+        if not processes:
+            logger.debug("No mitmdump/mitmproxy process found.")
+            return
+
         for p in processes:
             try:
+                logger.debug(f"Trying to gracefully shutdown mitmdump with pid {p.pid} on Linux/MacOS "
+                             f"inside kill_process().")
                 p.send_signal(signal.SIGINT)
             except psutil.AccessDenied:
+                logger.error(f"Access denied to kill process with pid {p.pid}.")
+                logger.debug(f"Trying to kill process with pid {p.pid}.")
                 p.kill()

--- a/pomodoro_task_app/website_blocker/website_blocker_manager.py
+++ b/pomodoro_task_app/website_blocker/website_blocker_manager.py
@@ -1,5 +1,6 @@
 import os
 import shlex
+import shutil
 import subprocess
 import threading
 
@@ -8,7 +9,8 @@ from PySide6.QtCore import QObject
 from uniproxy import Uniproxy
 
 from config_values import ConfigValues
-from constants import MITMDUMP_COMMAND_LINUX, MITMDUMP_COMMAND_WINDOWS
+from constants import MITMDUMP_COMMAND_LINUX, MITMDUMP_COMMAND_WINDOWS, MITMDUMP_SHUTDOWN_URL
+from utils.noHTTPClientError import NoHTTPClientError
 from website_blocker.utils import kill_process
 
 
@@ -47,10 +49,42 @@ class WebsiteBlockerManager(QObject):
 
     def stop_filtering(self, delete_proxy: bool = True):
         logger.debug("Inside WebsiteBlockerManager.stop_filtering().")
+
         if delete_proxy:
             threading.Thread(target=self.proxy.delete_proxy).start()
+
         try:
+            # detect if curl is installed
+            curl_path = shutil.which("curl")
+            # detect if wget is installed
+            wget_path = shutil.which("wget")
+
+            null_device = "NUL" if os.name == "nt" else "/dev/null"
+
+            if curl_path:
+                result = subprocess.run(
+                    [curl_path, "-s", "--proxy", f"127.0.0.1:{ConfigValues.PROXY_PORT}", MITMDUMP_SHUTDOWN_URL]
+                )
+                logger.debug(f"curl command return code: {result.returncode}")
+                if result.returncode == 7:
+                    logger.debug("curl return code 7: Most likely mitmproxy/mitmdump isn't running")
+            elif wget_path:
+                # https://askubuntu.com/a/586550
+                result = subprocess.run([
+                    wget_path,
+                    "-q",  # quiet mode
+                    "-O", null_device,  # discard output file
+                    "-e", "use_proxy=yes",
+                    "-e", f"http_proxy=http://127.0.0.1:{ConfigValues.PROXY_PORT}",
+                    MITMDUMP_SHUTDOWN_URL
+                ])
+                logger.debug(f"wget command return code: {result.returncode}")
+                if result.returncode == 4:
+                    logger.debug("wget return code 4: Most likely mitmproxy/mitmdump isn't running")
+            else:
+                raise NoHTTPClientError("Neither curl nor wget found.")
+        except Exception as e:
+            logger.error(f"Graceful shutdown of mitmdump failed: {e}")
+            # Fall back to force kill if graceful shutdown fails
+            logger.info("Falling back to force kill of mitmdump and mitmproxy.")
             kill_process()
-        # In case there are no mitmproxy processes open.
-        except:
-            pass


### PR DESCRIPTION
- Before this commit, on Windows, the setx command used to receive a CTRL+C signal when unsetting proxy environment variables after the pomodoro timer stopped. This was due to changes made in commit `509f3f47475d6c4ea7e9476e7969c12698d5261a`

- now using `ctx.master.shutdown()` method to aid in shutting down mitmdump when a special shutdown url is called using curl or wget. If neither curl or wget is present then mitmproxy is shutdown using SIGINT or SIGKILL and if on windows then it is simply killed

- However on killing the mitmdump instance, it will leave behind its _MEIxxxxxx folder created by pyinstaller (as the mitmdump binary is packaged using pyinstaller) in the OS's temp folder