### PR TITLE
fix(task_list_model.py): update task positions after removing a task

### DIFF
--- a/pomodoro_task_app/models/task_list_model.py
+++ b/pomodoro_task_app/models/task_list_model.py
@@ -292,6 +292,11 @@ class TaskListModel(QAbstractListModel):
             del self.tasks[row]
             logger.debug(f"tasks: {self.tasks}")
         self.endRemoveRows()
+
+        # Update task positions
+        for i, task in enumerate(self.tasks):
+            task["task_position"] = i
+
         self.layoutChanged.emit()
         return True
 


### PR DESCRIPTION
- before this fix, when a task was moved within the same task list, sometimes the task position (rows) used to start from 1 which led to incrementing time for the wrong task which isn't the current task