### PR TITLE
fix(pomodoro_view.py, main_window.py, bottomBar.py): update `pauseResumeButton` states to reflect correct icon and checked state

### DIFF
--- a/pomodoro_task_app/main_window.py
+++ b/pomodoro_task_app/main_window.py
@@ -246,7 +246,7 @@ class MainWindow(PomodoroFluentWindow):
         self.update_bottom_bar_timer_label()
 
         self.bottomBar.pauseResumeButton.setCheckable(True)
-        self.bottomBar.pauseResumeButton.setChecked(True)
+        self.bottomBar.pauseResumeButton.setChecked(False)
         self.bottomBar.pauseResumeButton.setIcon(FluentIcon.PLAY)
         self.bottomBar.pauseResumeButton.clicked.connect(self.bottomBarPauseResumeButtonClicked)
         self.bottomBar.skipButton.clicked.connect(self.pomodoro_interface.skipButtonClicked)
@@ -261,7 +261,7 @@ class MainWindow(PomodoroFluentWindow):
         self.pomodoro_interface.pauseResumeButtonClicked()
 
         # Update bottom bar button icon
-        if self.bottomBar.pauseResumeButton.isChecked():
+        if not self.bottomBar.pauseResumeButton.isChecked():
             self.bottomBar.pauseResumeButton.setIcon(FluentIcon.PLAY)
         else:
             self.bottomBar.pauseResumeButton.setIcon(FluentIcon.PAUSE)
@@ -416,7 +416,7 @@ class MainWindow(PomodoroFluentWindow):
         # get name of task by its ID
         current_task_name = self.task_interface.todoTasksList.model().getTaskNameById(self.get_current_task_id())
 
-        if not triggering_button.isChecked():
+        if triggering_button.isChecked():
             InfoBar.success(
                 title="Task Started",
                 content=f'Task named "{current_task_name}" has started',
@@ -601,10 +601,10 @@ class MainWindow(PomodoroFluentWindow):
 
     def setPauseResumeButtonsToPauseIcon(self, skip_delegate_button=False):
         self.pomodoro_interface.pauseResumeButton.setIcon(FluentIcon.PAUSE)
-        self.pomodoro_interface.pauseResumeButton.setChecked(False)
+        self.pomodoro_interface.pauseResumeButton.setChecked(True)
 
         self.bottomBar.pauseResumeButton.setIcon(FluentIcon.PAUSE)
-        self.bottomBar.pauseResumeButton.setChecked(False)
+        self.bottomBar.pauseResumeButton.setChecked(True)
 
         # todo: find why this is required
         if skip_delegate_button or self.get_current_task_id() is None:
@@ -618,10 +618,10 @@ class MainWindow(PomodoroFluentWindow):
 
     def setPauseResumeButtonsToPlayIcon(self, skip_delegate_button=False):
         self.pomodoro_interface.pauseResumeButton.setIcon(FluentIcon.PLAY)
-        self.pomodoro_interface.pauseResumeButton.setChecked(True)
+        self.pomodoro_interface.pauseResumeButton.setChecked(False)
 
         self.bottomBar.pauseResumeButton.setIcon(FluentIcon.PLAY)
-        self.bottomBar.pauseResumeButton.setChecked(True)
+        self.bottomBar.pauseResumeButton.setChecked(False)
 
         if skip_delegate_button or self.get_current_task_id() is None:
             return

--- a/pomodoro_task_app/prefabs/bottomBar.py
+++ b/pomodoro_task_app/prefabs/bottomBar.py
@@ -18,7 +18,7 @@ class BottomBar(Ui_BottomBarWidget, QWidget):
 
         self.stopButton.setCheckable(False)
         self.pauseResumeButton.setCheckable(True)
-        self.pauseResumeButton.setChecked(True)
+        self.pauseResumeButton.setChecked(False)  # Changed from True to False to match PLAY icon
         self.skipButton.setCheckable(False)
 
         self.stopButton.setToolTip("Stop")

--- a/pomodoro_task_app/views/subinterfaces/pomodoro_view.py
+++ b/pomodoro_task_app/views/subinterfaces/pomodoro_view.py
@@ -66,7 +66,7 @@ class PomodoroView(QWidget, Ui_PomodoroView):
 
         self.stopButton.setCheckable(False)
         self.pauseResumeButton.setCheckable(True)
-        self.pauseResumeButton.setChecked(True)
+        self.pauseResumeButton.setChecked(False)
         self.skipButton.setCheckable(False)
 
     def stopButtonClicked(self):
@@ -74,15 +74,15 @@ class PomodoroView(QWidget, Ui_PomodoroView):
         self.pomodoro_timer_obj.stopSession()
 
     def pauseResumeButtonClicked(self):
-        if self.pauseResumeButton.isChecked():
-            self.pauseResumeButton.setIcon(FluentIcon.PLAY)
-            self.pomodoro_timer_obj.pauseDuration()
-        else:
+        if self.pauseResumeButton.isChecked():  # Button is checked, show PAUSE icon (timer running)
             self.pauseResumeButton.setIcon(FluentIcon.PAUSE)
             if self.pomodoro_timer_obj.getTimerState() == TimerState.NOTHING:
                 self.pomodoro_timer_obj.updateSessionProgress(False)
             self.pomodoro_timer_obj.setDuration()
             self.pomodoro_timer_obj.startDuration()
+        else:
+            self.pauseResumeButton.setIcon(FluentIcon.PLAY)
+            self.pomodoro_timer_obj.pauseDuration()
 
     def correctPauseResumeButtonIcon(self, timer_state: TimerState):
         if timer_state == TimerState.NOTHING:
@@ -131,10 +131,10 @@ class PomodoroView(QWidget, Ui_PomodoroView):
     def skipButtonClicked(self):
         self.pomodoro_timer_obj.skipDuration()
         self.pauseResumeButton.setIcon(FluentIcon.PAUSE)
-        self.pauseResumeButton.setChecked(False)
+        self.pauseResumeButton.setChecked(True)
 
     def resetPauseResumeButton(self):
-        self.pauseResumeButton.setChecked(True)
+        self.pauseResumeButton.setChecked(False)
         self.pauseResumeButton.setIcon(FluentIcon.PLAY)
 
     def isInitialWorkSession(self):


### PR DESCRIPTION
- it was done so that it remains consistent with the button checked status of `TaskListItemDelegate`
- basically if `pauseResumeButton` of `BottomBar` and `PomodoroView` is checked then pause icon will be shown else play icon which is opposite of what it was before this commit